### PR TITLE
More aggressive typekit lookup

### DIFF
--- a/src/LogTask.cpp
+++ b/src/LogTask.cpp
@@ -64,6 +64,8 @@ bool LogTask::addStream(pocolog_cpp::InputDataStream& stream)
             task->ports()->addPort(portHandle->port->getName(), *portHandle->port);
             streamIdx2Port.emplace(stream.getIndex(), std::move(portHandle));
             return true;
+        } else {
+            unreplayablePorts.emplace(portName, stream.getCXXType());
         }
     }
 
@@ -203,7 +205,11 @@ LogTask::PortCollection LogTask::getPortCollection()
     for(const auto& portHandlePair : streamIdx2Port)
     {
         const auto& portHandle = portHandlePair.second;
-        collection.emplace_back(portHandle->name, portHandle->inputDataStream.getCXXType());
+        collection.replayable.emplace_back(PortInfo{portHandle->name, portHandle->inputDataStream.getCXXType()});
+    }
+    for(const auto& p : unreplayablePorts)
+    {
+        collection.unreplayable.emplace_back(PortInfo{p.first, p.second});
     }
 
     return collection;

--- a/src/LogTask.hpp
+++ b/src/LogTask.hpp
@@ -96,13 +96,19 @@ public:
      * @brief Alias for pair of port name and port type.
      *
      */
-    using PortInfo = std::pair<std::string, std::string>;
+    struct PortInfo {
+        std::string name;
+        std::string type;
+    };
 
     /**
-     * @brief Alias for list of PortInfo.
+     * @brief Structure holding two lists: replayable ports and unreplayable ports
      *
      */
-    using PortCollection = std::vector<PortInfo>;
+    struct PortCollection {
+        std::vector<PortInfo> replayable;
+        std::vector<PortInfo> unreplayable;
+    };
 
     /**
      * @brief Constructor.
@@ -236,4 +242,11 @@ private:
      *
      */
     std::map<uint64_t, std::unique_ptr<PortHandle>> streamIdx2Port;
+
+    /**
+     * @brief Map of stream names to types
+     *
+     * Used for showing which ports are present but cannot be replayed
+     */
+    std::map<std::string, std::string> unreplayablePorts;
 };

--- a/src/LogTaskManager.hpp
+++ b/src/LogTaskManager.hpp
@@ -41,16 +41,6 @@ public:
     };
 
     /**
-     * @brief Pair of port name and corresponding c++ data type.
-     */
-    using PortInfo = std::pair<std::string, std::string>;
-
-    /**
-     * @brief List of PortInfos.
-     */
-    using PortCollection = std::vector<PortInfo>;
-
-    /**
      * @brief Map of task name to corresponding list of PortInfos.
      */
     using TaskCollection = std::map<std::string, LogTask::PortCollection>;

--- a/src/LogTaskManager.hpp
+++ b/src/LogTaskManager.hpp
@@ -175,4 +175,9 @@ private:
      * 
      */
     std::map<std::string, std::string> renamings;
+
+    /**
+     * @brief Set to remember if we have already tried loading all typekits
+     */
+    bool haveLoadedAllTypeKits;
 };

--- a/src/ReplayHandler.cpp
+++ b/src/ReplayHandler.cpp
@@ -49,7 +49,7 @@ void ReplayHandler::deinit()
     }
 }
 
-std::map<std::string, std::vector<std::pair<std::string, std::string>>> ReplayHandler::getTaskNamesWithPorts()
+ReplayHandler::TaskCollection ReplayHandler::getTaskNamesWithPorts()
 {
     return manager.getTaskCollection();
 }

--- a/src/ReplayHandler.hpp
+++ b/src/ReplayHandler.hpp
@@ -15,6 +15,9 @@ class ReplayHandler
 {
 
 public:
+
+    using TaskCollection = LogTaskManager::TaskCollection;
+
     /**
      * @brief Constructor.
      *
@@ -118,7 +121,7 @@ public:
      * @brief Returns a map of task names with a list of their ports.
      * @return std::map<std::string, std::vector<std::string>> Map of task names with list of ports.
      */
-    std::map<std::string, std::vector<std::pair<std::string, std::string>>> getTaskNamesWithPorts();
+    TaskCollection getTaskNamesWithPorts();
 
     /**
      * @brief Returns the current sample timestamp.


### PR DESCRIPTION
This adds a single pass of orocos_cpp::PluginHelper::loadAllTypekitAndTransports() if a tasks model name cannot be used for its typekit lookup. This ensures that samples from any of the already installed typekits can be replayed even if the task has not been installed.

This does not prevent a type mismatch when the log file has a different type with the same name. To get that case working, one would need to construct a typekit on-the-fly from the information in the streams type registry.

The rest fixes a problem where OrocosCpp was instantiated twice, preventing the above to be debugged properly because the logtaskmanagers orocos instance would not be initialized properly, and displays the unreplayable ports in the gui instead of a) not having the task or b) not having the port, without any indication what is going on.